### PR TITLE
Add support for coercing non-JSON supported types to their python values

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -229,6 +229,11 @@ class ObjectIdField(BaseField):
     """
 
     def to_python(self, value):
+        if not isinstance(value, bson.objectid.ObjectId):
+            try:
+                return bson.objectid.ObjectId(unicode(value))
+            except Exception:
+                return value
         return value
         # return unicode(value)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -16,7 +16,7 @@ import datetime
 import decimal
 import warnings
 import types
-
+import ciso8601
 
 __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
            'DateTimeField', 'EmbeddedDocumentField', 'ListField', 'DictField',
@@ -239,6 +239,26 @@ class BooleanField(BaseField):
 class DateTimeField(BaseField):
     """A datetime field.
     """
+
+    def to_python(self, value):
+        if isinstance(value, datetime.datetime):
+            return value
+        elif isinstance(value, basestring):
+            try:
+                return ciso8601.parse_datetime_unaware(value)
+            except Exception:
+                return value
+        return value
+
+    def to_mongo(self, value):
+        if isinstance(value, datetime.datetime):
+            return value
+        elif isinstance(value, basestring):
+            try:
+                return ciso8601.parse_datetime_unaware(value)
+            except Exception:
+                return value
+        return value
 
     def validate(self, value):
         assert isinstance(value, datetime.datetime)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo'],
+      install_requires=['pymongo','ciso8601'],
       test_suite='tests',
       tests_require=['blinker', 'django==1.3']
 )


### PR DESCRIPTION
Dataman uses JSON, and json doesn't support these types natively. Instead of muddling that logic into the serialization/deserialization, we know enough about the types from the Document model to coerce them into the right type on read