### PR TITLE
Do not append branch name to egg name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,10 +19,6 @@ upload_egg:
     # update version to put custom ContextLogic version
     - version_cl="return version + '+cl$CI_PIPELINE_ID'"
     - sed -i "s/return version/$version_cl/g" setup.py
-    # update name to put the branch name in it
-    - name_origin=$(sed -n "/.*\(name\).*=.*'.*/p" setup.py | sed "/.*'\(.*\)'.*/ s//\1/g")
-    - name_cl="name='$name_origin-$BRANCH_NAME'"
-    - sed -i "s/name.*=.*'mongoengine'/$name_cl/g" setup.py
 
     # Install
     - pip install .


### PR DESCRIPTION
If you append the branch name and install the egg as is, any dependencies will not be able to recognize it, even if you can import it, e.g for another repo:

vitaliy@vitaliy:~$ mypypi/bin/pip freeze | grep "tornado" DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support tornado-branch4.5.1==4.5.2+cl93807

vitaliy@vitaliy:~$ mypypi/bin/pip install h2tornado==0.0.2 DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support Looking in indexes: https://pypi.infra.wish.com/simple/ Collecting h2tornado==0.0.2 Downloading https://pypi.infra.wish.com/api/package/h2tornado/h2tornado-0.0.2.tar.gz Collecting tornado>=4.5 (from h2tornado==0.0.2) Downloading https://pypi.infra.wish.com/api/package/tornado/tornado-6.0.3.tar.gz (482kB) |████████████████████████████████| 491kB 27.4MB/s ERROR: Package 'tornado' requires a different Python: 2.7.15 not in '>= 3.5'