### PR TITLE
Fix pipeline failure due to incorrect naming

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ upload_egg:
 
     # Install
     - pip install .
-    - pip show $name_origin-$BRANCH_NAME
+    - pip show $CI_PROJECT_NAME
 
     # Upload to pypicloud
     - pip install twine


### PR DESCRIPTION
Fixes the error from this run

https://gitlab.i.wish.com/ContextLogic/mongoengine/pipelines/126251