### PR TITLE
Fix some minor mongoengine bugs + bump version

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
 
 __author__ = 'Harry Marr'
 
-VERSION = (0, 4, 2)
+VERSION = (0, 4, 3)
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -182,9 +182,9 @@ class Document(BaseDocument):
                     object_id = collection.save(doc, w=w)
         except (pymongo.errors.OperationFailure, ProxiedGrpcError, RPCException), err:
             message = 'Could not save document (%s)'
-            if u'duplicate key' in unicode(err):
+            if u'duplicate key' in unicode(err, errors='replace'):
                 message = u'Tried to save duplicate unique keys (%s)'
-            raise OperationError(message % unicode(err))
+            raise OperationError(message % unicode(err, errors='replace'))
         id_field = self._meta['id_field']
         self[id_field] = self._fields[id_field].to_python(object_id)
 


### PR DESCRIPTION
Summary:
1) If there was an $or query object id fields had to explicitly cast to
object ids, instead of being automatically casted like other cases. This
was caused by the op staying as "or" forever.
2) Sentry error caused by unicode error instead of a duplicate key
error: https://sentry.infra.wish.com/sentry/merchant-external-api/issues/462/?query=is:unresolved

Test Plan: inprod

Reviewers: jji, tjackson, vitaliy

Differential Revision: https://phab.wish.com/D105654