### PR TITLE
 Fix or queries breaking object id validation for other columns

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1528,6 +1528,8 @@ class Document(BaseDocument):
                            '$max', '$min', '$showDiskLoc', '$hint', '$comment',
                            '$slice', '$options', '$regex', '$position']
 
+        base_op = op
+
         # recurse on list, unless we're at a ListField
         if isinstance(value, list) and not isinstance(context, ListField):
             transformed_list = []
@@ -1538,6 +1540,8 @@ class Document(BaseDocument):
                     for key, subvalue in listel.iteritems():
                         if key[0] == '$':
                             op = key
+                        else:
+                            op = base_op
 
                         new_key, value_context = Document._transform_key(key, context,
                                                      is_find=(op is None))
@@ -1560,6 +1564,8 @@ class Document(BaseDocument):
                 embeddeddoc = False
                 if key[0] == '$':
                     op = key
+                else:
+                    op = base_op
 
                 if isinstance(context, ListField):
                     if isinstance(context.field, EmbeddedDocumentField):

--- a/tests/custom_queries.py
+++ b/tests/custom_queries.py
@@ -201,6 +201,16 @@ class CustomQueryTest(unittest.TestCase):
         self.assertEqual(result['$set']['name'], 'Chu')
         self.assertEqual(result['$set']['c'], {'n': 'Blue'})
 
+    def testTransformQueryEmbeddedOrder(self):
+        blue = self.Colour(name='Blue')
+        query = {'$or': {'name': 'Chu', 'age': 20, 'favourite_colour': blue},
+                'some_id' : '0' * 24}
+        result = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(result['some_id'], ObjectId('0'*24))
+
+
+
     def testTransformQueryList(self):
         blue = self.Colour(name='Blue')
         red = self.Colour(name='Red')


### PR DESCRIPTION
Fixes $or queries breaking transformed values later down the line.

This is caused because the $or query key in a dict goes to first/close to the first part of for loops do to the hashing, and this causes the op key to be validate everything as if it is in a $or query, which doesn't cast strings to object ids if needed.

I still do not know how to test this properly as I don't have my environment set up locally to run mongo engine (I might try modifying the code inside a container and trying it there) -- this is why this wasn't landed last time, but people keep on noticing it and it bugs me.