### PR TITLE
Disallow disk use

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1003,7 +1003,7 @@ class Document(BaseDocument):
 
     @classmethod
     def aggregate(cls, pipeline=None, **kwargs):
-        if "allowDiskUse" in kwargs and kwargs["allowDiskUse"] == True:
+        if kwargs.get('allowDiskUse', False):
             raise ValueError("Writing to temporary files is disabled. allowDiskUse=True is not allowed.")
 
         proxy_client = cls._get_proxy_client()

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -127,7 +127,10 @@ class Document(BaseDocument):
         if self.__class__._bulk_op is not None:
             warnings.warn('Non-bulk update inside bulk operation')
 
+        print "save: "
         proxy_client = self._get_proxy_client()
+        print "proxy_client: "
+        print proxy_client
 
         if self._meta['hash_field']:
             # if we're hashing the ID and it hasn't been set yet, autogenerate it
@@ -1003,6 +1006,9 @@ class Document(BaseDocument):
 
     @classmethod
     def aggregate(cls, pipeline=None, **kwargs):
+        if "allowDiskUse" in kwargs and kwargs["allowDiskUse"] == True:
+            raise ValueError("Writing to temporary files is disabled. allowDiskUse=True is not allowed.")
+
         proxy_client = cls._get_proxy_client()
         if proxy_client:
             if cls._get_read_decider():

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -127,10 +127,7 @@ class Document(BaseDocument):
         if self.__class__._bulk_op is not None:
             warnings.warn('Non-bulk update inside bulk operation')
 
-        print "save: "
         proxy_client = self._get_proxy_client()
-        print "proxy_client: "
-        print proxy_client
 
         if self._meta['hash_field']:
             # if we're hashing the ID and it hasn't been set yet, autogenerate it


### PR DESCRIPTION
Ticket: https://jira.wish.site/browse/CORE-161



Create a test collection: 
```
import mongoengine.fields as f
from mongoengine import Document
from cl.utils.mongo import MongoMixin

class TestPerson(Document, MongoMixin):
    meta = MongoMixin.NO_INHERIT()
    meta["shard_key"] = None

    name = f.StringField(db_field="n")
    age = f.IntField(db_field="a")


    @classmethod
    def create(cls, name, age):
        obj = cls(name=name, age=age)
        obj.save()

    @classmethod
    def test_aggregate_disallow_disk(cls):
        pipeline = [
            {
                "$group": {
                    "_id": {"n": "$n", "a": "$a"},
                    "count": {"$sum": 1}
                }
            },
            {
                "$match": {
                    "count": {"$gt": 1}
                }
            }
        ]
        results = cls.aggregate(pipeline)
        print results


    @classmethod
    def test_aggregate_allow_disk(cls):
        pipeline = [
            {
                "$group": {
                    "_id": {"n": "$n", "a": "$a"},
                    "count": {"$sum": 1}
                }
            },
            {
                "$match": {
                    "count": {"$gt": 1}
                }
            }
        ]
        results = cls.aggregate(pipeline, allowDiskUse=True)
        print results
```

Run test_aggregate_disallow_disk() and test_aggregate_allow_disk() in dbshell:
```
In [1]:  TestPerson.test_aggregate_disallow_disk()
{'result': [{u'count': 3, u'_id': {u'a': 12, u'n': u'jim'}}, {u'count': 3, u'_id': {u'a': 65, u'n': u'jack'}}, {u'count': 3, u'_id': {u'a': 35, u'n': u'eric'}}]}

In [2]: TestPerson.test_aggregate_allow_disk()
{'result': [{u'count': 3, u'_id': {u'a': 12, u'n': u'jim'}}, {u'count': 3, u'_id': {u'a': 65, u'n': u'jack'}}, {u'count': 3, u'_id': {u'a': 35, u'n': u'eric'}}]}
```
It does not raise any exception. I assume that after merging the pr, we will see the difference?


One thing I want to mention is that the aggregate() function defined in mongoengine does not pass the **kwargs(such as allowDiskUse) to mongo proxy. So I think whatever paramters the user pass in this aggregate() function will not be sent to mongo proxy. The definition of aggregate() function in mongoengine is here: https://github.com/ContextLogic/mongoengine/blob/c1b810825358343def2b7ee660d3f323219b7720/mongoengine/document.py#L1005
